### PR TITLE
feat: Enable Markdown input and rendering for notes

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,11 @@
 import 'package:flutter/material.dart';
+import 'dart:io'; // For File operations
+import 'package:file_picker/file_picker.dart'; // For file picking
+import 'package:paddy/models/note.dart';
+import 'package:paddy/screens/note_edit_screen.dart'; // Import NoteEditScreen
+import 'package:paddy/widgets/note_card.dart';
 import 'package:sizer/sizer.dart';
+import 'package:google_fonts/google_fonts.dart'; // Import Google Fonts
 
 void main() {
   runApp(MyApp());
@@ -9,13 +15,48 @@ class MyApp extends StatelessWidget {
   // This widget is the root of your application.
   @override
   Widget build(BuildContext context) {
+    final baseTheme = ThemeData.light(); // Start with a light theme baseline
+
     return Sizer(builder: (context, orientation, screenType) {
       return MaterialApp(
-        title: 'Paddy',
-        theme: ThemeData(
-          primaryColor: Color(0xFFFDFFB6),
+        title: 'Paddy Notes',
+        theme: baseTheme.copyWith(
+          primaryColor: const Color(0xFFFDFFB6), // Light yellow, good for accents
+          scaffoldBackgroundColor: const Color(0xFFFDF5E6), // Old Lace for paper feel
+          appBarTheme: AppBarTheme(
+            backgroundColor: const Color(0xFFFFF0C1), // Complementary to Old Lace
+            foregroundColor: Colors.brown[800], // Dark brown for text/icons
+            elevation: 1.0,
+            titleTextStyle: GoogleFonts.lato(
+              fontSize: 20,
+              fontWeight: FontWeight.bold,
+              color: Colors.brown[800],
+            ),
+          ),
+          colorScheme: ColorScheme.fromSeed(
+            seedColor: const Color(0xFFFDFFB6), // Primary yellow
+            brightness: Brightness.light,
+            background: const Color(0xFFFDF5E6), // Paper color for background
+          ),
+          textTheme: GoogleFonts.latoTextTheme(baseTheme.textTheme).copyWith(
+            // Titles and UI elements using Lato
+            displayLarge: GoogleFonts.lato(textStyle: baseTheme.textTheme.displayLarge),
+            displayMedium: GoogleFonts.lato(textStyle: baseTheme.textTheme.displayMedium),
+            displaySmall: GoogleFonts.lato(textStyle: baseTheme.textTheme.displaySmall),
+            headlineLarge: GoogleFonts.lato(textStyle: baseTheme.textTheme.headlineLarge),
+            headlineMedium: GoogleFonts.lato(textStyle: baseTheme.textTheme.headlineMedium),
+            headlineSmall: GoogleFonts.lato(textStyle: baseTheme.textTheme.headlineSmall),
+            titleLarge: GoogleFonts.lato(textStyle: baseTheme.textTheme.titleLarge),
+            titleMedium: GoogleFonts.lato(textStyle: baseTheme.textTheme.titleMedium),
+            titleSmall: GoogleFonts.lato(textStyle: baseTheme.textTheme.titleSmall),
+            // Body text using Roboto Slab
+            bodyLarge: GoogleFonts.robotoSlab(textStyle: baseTheme.textTheme.bodyLarge),
+            bodyMedium: GoogleFonts.robotoSlab(textStyle: baseTheme.textTheme.bodyMedium),
+            bodySmall: GoogleFonts.robotoSlab(textStyle: baseTheme.textTheme.bodySmall),
+          ),
+          useMaterial3: true,
         ),
-        home: MyHomePage(title: 'Paddy'),
+        home: MyHomePage(title: 'Paddy Notes'),
       );
     });
   }
@@ -31,8 +72,199 @@ class MyHomePage extends StatefulWidget {
 }
 
 class _MyHomePageState extends State<MyHomePage> {
+  // Updated notes list
+  final List<Note> _notes = [
+    Note(id: '1', title: 'My First Note', content: 'This is the content of my first note. It is very exciting!', timestamp: DateTime.now()),
+    Note(id: '2', title: 'Shopping List', content: 'Milk, Eggs, Bread, Coffee', timestamp: DateTime.now().subtract(const Duration(days: 1))),
+    Note(id: '3', title: 'Ideas for project', content: 'Think about UI, state management, and persistence.', timestamp: DateTime.now().subtract(const Duration(hours: 2))),
+  ];
+
+  // Function to add a new note
+  void _addNote(Note note) {
+    setState(() {
+      _notes.add(note);
+    });
+  }
+
+  // Function to update an existing note
+  void _updateNote(Note note) {
+    setState(() {
+      final index = _notes.indexWhere((n) => n.id == note.id);
+      if (index != -1) {
+        _notes[index] = note;
+      }
+    });
+  }
+
+  // Function to delete a note
+  void _deleteNote(String id) {
+    setState(() {
+      _notes.removeWhere((note) => note.id == id);
+    });
+  }
+
+  // Function to show delete confirmation dialog
+  Future<void> _showDeleteConfirmationDialog(String noteId, String noteTitle) async {
+    return showDialog<void>(
+      context: context,
+      barrierDismissible: false, // user must tap button!
+      builder: (BuildContext dialogContext) {
+        return AlertDialog(
+          title: const Text('Delete Note?'),
+          content: SingleChildScrollView(
+            child: ListBody(
+              children: <Widget>[
+                Text('Are you sure you want to delete the note titled "$noteTitle"?'),
+                const Text('This action cannot be undone.'),
+              ],
+            ),
+          ),
+          actions: <Widget>[
+            TextButton(
+              child: const Text('Cancel'),
+              onPressed: () {
+                Navigator.of(dialogContext).pop(); // Dismiss the dialog
+              },
+            ),
+            TextButton(
+              child: const Text('Delete'),
+              style: TextButton.styleFrom(foregroundColor: Colors.red), // Make delete button red
+              onPressed: () {
+                _deleteNote(noteId);
+                Navigator.of(dialogContext).pop(); // Dismiss the dialog
+              },
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  // Function to export notes to Markdown
+  Future<void> _exportNotesToMarkdown() async {
+    // Ensure the widget is still mounted before showing SnackBars or interacting with context
+    if (!mounted) return;
+
+    try {
+      String? selectedDirectory = await FilePicker.platform.getDirectoryPath();
+
+      if (selectedDirectory == null) {
+        // User canceled the picker
+        if (!mounted) return;
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Directory selection canceled.')),
+        );
+        return;
+      }
+
+      int successCount = 0;
+      int errorCount = 0;
+      for (final note in _notes) {
+        final String fileName = "${note.id}.md"; // Using ID for safe filename
+        final String markdownContent = "# ${note.title}\n\n${note.content}";
+        final File file = File("$selectedDirectory/$fileName");
+
+        try {
+          await file.writeAsString(markdownContent);
+          successCount++;
+        } catch (e) {
+          errorCount++;
+          debugPrint('Error writing file for note ${note.id}: $e');
+          // Optionally, collect errors and show a summary
+        }
+      }
+
+      if (!mounted) return;
+      String message = '$successCount notes exported successfully to $selectedDirectory';
+      if (errorCount > 0) {
+        message += '\n$errorCount notes failed to export.';
+      }
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(message)),
+      );
+
+    } catch (e) {
+      debugPrint('Error during export: $e');
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('An error occurred during export: $e')),
+      );
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
-    return Scaffold();
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(widget.title), // Set AppBar title
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.ios_share),
+            tooltip: 'Export Notes to Markdown',
+            onPressed: _exportNotesToMarkdown,
+          ),
+        ],
+      ),
+      body: ListView.separated(
+        itemCount: _notes.length,
+        itemBuilder: (context, index) {
+          final note = _notes[index];
+          return InkWell(
+            onTap: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (context) => NoteEditScreen(
+                    note: note, // Pass the existing note
+                    onSave: (title, content) {
+                      _updateNote(Note(
+                        id: note.id, // Keep original ID
+                        title: title,
+                        content: content,
+                        timestamp: DateTime.now(), // Update timestamp
+                      ));
+                    },
+                  ),
+                ),
+              );
+            },
+            onLongPress: () {
+              _showDeleteConfirmationDialog(note.id, note.title);
+            },
+            child: NoteCard(note: note),
+          );
+        },
+        separatorBuilder: (context, index) {
+          return Divider(
+            color: Colors.brown.withOpacity(0.25), // Subtle brown line, slightly more transparent
+            height: 1,
+            thickness: 0.7, // Slightly thinner
+            indent: 20, // Indent from the left
+            endIndent: 20, // Indent from the right
+          );
+        },
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () {
+          Navigator.push(
+            context,
+            MaterialPageRoute(
+              builder: (context) => NoteEditScreen(
+                onSave: (title, content) {
+                  _addNote(Note(
+                    id: DateTime.now().millisecondsSinceEpoch.toString(),
+                    title: title,
+                    content: content,
+                    timestamp: DateTime.now(),
+                  ));
+                },
+              ),
+            ),
+          );
+        },
+        tooltip: 'Add Note',
+        child: const Icon(Icons.add),
+      ),
+    );
   }
 }

--- a/lib/models/note.dart
+++ b/lib/models/note.dart
@@ -1,0 +1,13 @@
+class Note {
+  String id;
+  String title;
+  String content;
+  DateTime timestamp;
+
+  Note({
+    required this.id,
+    required this.title,
+    required this.content,
+    required this.timestamp,
+  });
+}

--- a/lib/screens/note_edit_screen.dart
+++ b/lib/screens/note_edit_screen.dart
@@ -1,0 +1,110 @@
+import 'package:flutter/material.dart';
+import 'package:paddy/models/note.dart';
+
+class NoteEditScreen extends StatefulWidget {
+  final Note? note;
+  final Function(String title, String content)? onSave;
+
+  const NoteEditScreen({Key? key, this.note, this.onSave}) : super(key: key);
+
+  @override
+  _NoteEditScreenState createState() => _NoteEditScreenState();
+}
+
+class _NoteEditScreenState extends State<NoteEditScreen> {
+  late TextEditingController _titleController;
+  late TextEditingController _contentController;
+
+  bool get _isEditing => widget.note != null;
+
+  @override
+  void initState() {
+    super.initState();
+    _titleController = TextEditingController(text: widget.note?.title ?? '');
+    _contentController = TextEditingController(text: widget.note?.content ?? '');
+  }
+
+  @override
+  void dispose() {
+    _titleController.dispose();
+    _contentController.dispose();
+    super.dispose();
+  }
+
+  void _saveNote() {
+    final title = _titleController.text;
+    final content = _contentController.text;
+
+    if (widget.onSave != null) {
+      widget.onSave!(title, content);
+    }
+
+    // Pop screen
+    if (Navigator.canPop(context)) {
+      Navigator.pop(context);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(_isEditing ? 'Edit Note' : 'New Note'),
+        actions: [
+          TextButton(
+            onPressed: _saveNote,
+            child: Text(
+              'Save',
+              style: GoogleFonts.lato( // Consistent with AppBar title style
+                color: Colors.brown[800],
+                fontWeight: FontWeight.bold,
+                fontSize: 16,
+              ),
+            ),
+          ),
+        ],
+      ),
+      backgroundColor: Theme.of(context).scaffoldBackgroundColor, // Ensure paper background
+      body: Padding(
+        padding: const EdgeInsets.fromLTRB(16.0, 8.0, 16.0, 16.0), // Adjust top padding
+        child: Column(
+          children: <Widget>[
+            TextField(
+              controller: _titleController,
+              decoration: InputDecoration(
+                hintText: 'Title',
+                border: InputBorder.none, // Minimalist look
+                hintStyle: GoogleFonts.lato(color: Colors.brown[300], fontSize: 22, fontWeight: FontWeight.bold),
+              ),
+              style: GoogleFonts.lato( // Title font
+                fontSize: 22,
+                fontWeight: FontWeight.bold,
+                color: Colors.brown[800],
+              ),
+            ),
+            const SizedBox(height: 8.0), // Reduced space
+            Expanded(
+              child: TextField(
+                controller: _contentController,
+                decoration: InputDecoration(
+                  hintText: 'Start writing your note here...',
+                  border: InputBorder.none, // Minimalist look
+                  hintStyle: GoogleFonts.robotoSlab(color: Colors.brown[300], fontSize: 16),
+                  alignLabelWithHint: true,
+                ),
+                style: GoogleFonts.robotoSlab( // Content font
+                  fontSize: 16,
+                  color: Colors.brown[700],
+                  height: 1.5, // Improved line spacing for readability
+                ),
+                maxLines: null,
+                expands: true,
+                textAlignVertical: TextAlignVertical.top,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/note_card.dart
+++ b/lib/widgets/note_card.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_markdown/flutter_markdown.dart'; // Import flutter_markdown
+import 'package:google_fonts/google_fonts.dart'; // Ensure GoogleFonts is imported
+import '../models/note.dart';
+
+class NoteCard extends StatelessWidget {
+  final Note note;
+
+  const NoteCard({Key? key, required this.note}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      color: const Color(0xFFFFF0C1), // A slightly more saturated yellow than background
+      margin: const EdgeInsets.symmetric(horizontal: 12.0, vertical: 6.0),
+      elevation: 2.0, // Subtle shadow
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(8.0),
+        // side: BorderSide(color: Colors.brown.withOpacity(0.2), width: 1), // Optional subtle border
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              note.title,
+              style: GoogleFonts.lato( // Title font from theme
+                fontSize: 17.0,
+                fontWeight: FontWeight.bold,
+                color: Colors.brown[800],
+              ),
+            ),
+            const SizedBox(height: 8.0),
+            // Replace Text widget with MarkdownBody
+            MarkdownBody(
+              data: note.content, // Using full content as per initial instruction
+              // Applying styleSheet to maintain consistency with the theme
+              styleSheet: MarkdownStyleSheet.fromTheme(Theme.of(context)).copyWith(
+                p: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                      fontFamily: GoogleFonts.robotoSlab().fontFamily,
+                      fontSize: 14.0,
+                      color: Colors.brown[700],
+                    ),
+                // Example for other tags if needed, but keeping it simple for now
+                // h1: Theme.of(context).textTheme.headlineSmall?.copyWith(fontFamily: GoogleFonts.lato().fontFamily),
+                // listBullet: TextStyle(fontFamily: GoogleFonts.robotoSlab().fontFamily, fontSize: 14.0, color: Colors.brown[700]),
+              ),
+              // Note: MarkdownBody does not have a direct maxLines or overflow property.
+              // Truncation would need to happen on the `data` string itself if strict line limits are needed.
+              // For now, allowing it to render and relying on card constraints.
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -29,6 +29,9 @@ dependencies:
   cupertino_icons: ^1.0.2
   sizer: ^2.0.13
   google_fonts: ^2.1.0
+  file_picker: ^5.3.0
+  path_provider: ^2.0.12
+  flutter_markdown: ^0.6.10
 
 dev_dependencies:
   flutter_test:

--- a/test/unit/note_test.dart
+++ b/test/unit/note_test.dart
@@ -1,0 +1,21 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:paddy/models/note.dart'; // Adjust the import path as necessary
+
+void main() {
+  group('Note Model', () {
+    test('Note instantiation and property access', () {
+      final timestamp = DateTime.now();
+      final note = Note(
+        id: 'test_id',
+        title: 'Test Title',
+        content: 'Test Content',
+        timestamp: timestamp,
+      );
+
+      expect(note.id, 'test_id');
+      expect(note.title, 'Test Title');
+      expect(note.content, 'Test Content');
+      expect(note.timestamp, timestamp);
+    });
+  });
+}

--- a/test/widget/note_card_test.dart
+++ b/test/widget/note_card_test.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_markdown/flutter_markdown.dart'; // Import flutter_markdown
+import 'package:paddy/models/note.dart'; // Adjust path as necessary
+import 'package:paddy/widgets/note_card.dart'; // Adjust path as necessary
+
+void main() {
+  group('NoteCard Widget', () {
+    testWidgets('Displays note title and Markdown content', (WidgetTester tester) async {
+      // Create a sample Note object
+      final sampleNote = Note(
+        id: 'test_id',
+        title: 'Test Note Title',
+        content: 'This is the *Markdown* test content of the note, which might be a bit long.',
+        timestamp: DateTime.now(),
+      );
+
+      // Pump the NoteCard widget with this note inside a MaterialApp
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold( // Scaffold provides Directionality and basic Material structure
+            body: NoteCard(note: sampleNote),
+          ),
+        ),
+      );
+
+      // Verify that the note's title is displayed
+      expect(find.text('Test Note Title'), findsOneWidget);
+
+      // Verify that MarkdownBody is present and displays the correct Markdown data
+      final markdownBodyFinder = find.byType(MarkdownBody);
+      expect(markdownBodyFinder, findsOneWidget);
+      final MarkdownBody markdownBodyWidget = tester.widget<MarkdownBody>(markdownBodyFinder);
+      expect(markdownBodyWidget.data, equals(sampleNote.content));
+    });
+  });
+}

--- a/test/widget/note_edit_screen_test.dart
+++ b/test/widget/note_edit_screen_test.dart
@@ -1,0 +1,126 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:paddy/models/note.dart'; // Adjust path
+import 'package:paddy/screens/note_edit_screen.dart'; // Adjust path
+
+void main() {
+  group('NoteEditScreen Widget', () {
+    // Helper function to pump NoteEditScreen within a MaterialApp
+    Future<void> pumpNoteEditScreen(
+      WidgetTester tester, {
+      Note? note,
+      required Function(String title, String content) onSave,
+    }) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: NoteEditScreen(note: note, onSave: onSave),
+        ),
+      );
+    }
+
+    testWidgets('Displays empty fields for a new note', (WidgetTester tester) async {
+      await pumpNoteEditScreen(tester, onSave: (title, content) {});
+
+      // Verify title TextField is present and empty
+      final titleField = find.byWidgetPredicate(
+        (widget) => widget is TextField && widget.decoration?.hintText == 'Title',
+      );
+      expect(titleField, findsOneWidget);
+      expect(tester.widget<TextField>(titleField).controller?.text, isEmpty);
+
+      // Verify content TextField is present and empty
+      final contentField = find.byWidgetPredicate(
+        (widget) => widget is TextField && widget.decoration?.hintText == 'Start writing your note here...',
+      );
+      expect(contentField, findsOneWidget);
+      expect(tester.widget<TextField>(contentField).controller?.text, isEmpty);
+
+      // Verify "Save" button is present
+      expect(find.widgetWithText(TextButton, 'Save'), findsOneWidget);
+    });
+
+    testWidgets('Displays note data when editing an existing note', (WidgetTester tester) async {
+      final note = Note(
+        id: 'edit_id',
+        title: 'Editable Title',
+        content: 'Editable Content',
+        timestamp: DateTime.now(),
+      );
+
+      await pumpNoteEditScreen(tester, note: note, onSave: (title, content) {});
+
+      // Verify title TextField displays the note's title
+      final titleField = find.byWidgetPredicate(
+        (widget) => widget is TextField && widget.decoration?.hintText == 'Title',
+      );
+      expect(tester.widget<TextField>(titleField).controller?.text, 'Editable Title');
+
+      // Verify content TextField displays the note's content
+      final contentField = find.byWidgetPredicate(
+        (widget) => widget is TextField && widget.decoration?.hintText == 'Start writing your note here...',
+      );
+      expect(tester.widget<TextField>(contentField).controller?.text, 'Editable Content');
+    });
+
+    testWidgets('Calls onSave callback when save button is tapped', (WidgetTester tester) async {
+      bool wasOnSaveCalled = false;
+      String? savedTitle;
+      String? savedContent;
+
+      await pumpNoteEditScreen(
+        tester,
+        onSave: (title, content) {
+          wasOnSaveCalled = true;
+          savedTitle = title;
+          savedContent = content;
+        },
+      );
+
+      // Enter some text into the title and content fields
+      final titleField = find.byWidgetPredicate(
+        (widget) => widget is TextField && widget.decoration?.hintText == 'Title',
+      );
+      await tester.enterText(titleField, 'New Title');
+
+      final contentField = find.byWidgetPredicate(
+        (widget) => widget is TextField && widget.decoration?.hintText == 'Start writing your note here...',
+      );
+      await tester.enterText(contentField, 'New Content');
+
+      // Find the "Save" button and tap it
+      await tester.tap(find.widgetWithText(TextButton, 'Save'));
+      await tester.pumpAndSettle(); // Wait for navigation/animations
+
+      // Expect onSave to have been called
+      expect(wasOnSaveCalled, isTrue);
+      expect(savedTitle, 'New Title');
+      expect(savedContent, 'New Content');
+    });
+
+    testWidgets('Saves raw Markdown content', (WidgetTester tester) async {
+      String rawMarkdownInput = "*bold text* and _italic_ with a # heading";
+      String? capturedContent;
+
+      await pumpNoteEditScreen(
+        tester,
+        onSave: (title, content) {
+          capturedContent = content; // Capture the content passed to onSave
+        },
+      );
+
+      // Enter raw Markdown into the content field
+      final contentField = find.byWidgetPredicate(
+        (widget) => widget is TextField && widget.decoration?.hintText == 'Start writing your note here...',
+      );
+      expect(contentField, findsOneWidget);
+      await tester.enterText(contentField, rawMarkdownInput);
+
+      // Tap the "Save" button
+      await tester.tap(find.widgetWithText(TextButton, 'Save'));
+      await tester.pumpAndSettle(); // Wait for navigation/animations
+
+      // Verify that the captured content is the same as the raw Markdown input
+      expect(capturedContent, equals(rawMarkdownInput));
+    });
+  });
+}


### PR DESCRIPTION
This commit introduces support for writing notes in Markdown format and rendering them within the app.

Key changes:
- Integrated the `flutter_markdown` package.
- NoteCard (`lib/widgets/note_card.dart`) now uses `MarkdownBody` to display note content, rendering Markdown to rich text.
- NoteEditScreen (`lib/screens/note_edit_screen.dart`) now serves as a raw Markdown input field.
- Verified that the "Export to Markdown" feature correctly uses the raw Markdown content for export.
- Updated widget tests for NoteCard and NoteEditScreen to ensure Markdown rendering and saving logic are tested.

You can now write notes using Markdown syntax and see them displayed with appropriate formatting in the note list.